### PR TITLE
feat(RefSubject): get/unsafeGet(Exit)

### DIFF
--- a/.changeset/thirty-ants-complain.md
+++ b/.changeset/thirty-ants-complain.md
@@ -1,0 +1,5 @@
+---
+"@typed/fx": minor
+---
+
+RefSubject get/unsafeGet(Exit)

--- a/packages/fx/src/FormEntry.ts
+++ b/packages/fx/src/FormEntry.ts
@@ -6,6 +6,7 @@ import type { ParseOptions } from "@effect/schema/AST"
 import { type ParseError } from "@effect/schema/ParseResult"
 import type { Cause } from "effect/Cause"
 import * as Effect from "effect/Effect"
+import type { Exit } from "effect/Exit"
 import type * as Scope from "effect/Scope"
 import * as Fx from "./Fx.js"
 import { FxEffectBase } from "./internal/protos.js"
@@ -187,6 +188,8 @@ class FromEntryImpl<R, E, I, O> extends FxEffectBase<I, E | ParseError, R | Scop
   ): Effect.Effect<B, E2, R | R2> {
     return this.ref.runUpdates(f)
   }
+
+  unsafeGet: () => Exit<I, E | ParseError> = () => this.ref.unsafeGet()
 
   onFailure(cause: Cause<E | ParseError>): Effect.Effect<unknown, never, R> {
     return this.ref.onFailure(cause)

--- a/packages/fx/test/core.ts
+++ b/packages/fx/test/core.ts
@@ -400,6 +400,32 @@ describe.concurrent(__filename, () => {
         await Effect.runPromise(Effect.scoped(test))
       })
     })
+
+    describe.concurrent("unsafe", () => {
+      it.concurrent("unsafeGetExit", async () => {
+        const test = Effect.gen(function*(_) {
+          // of() actually has a starting value by default
+          const ref = yield* _(RefSubject.of(0))
+
+          const exit = RefSubject.unsafeGetExit(ref)
+          expect(exit).toEqual(Exit.succeed(0))
+        }).pipe(Effect.scoped)
+
+        await Effect.runPromise(test)
+      })
+
+      it.concurrent("unsafeGet", async () => {
+        const test = Effect.gen(function*(_) {
+          const ref = yield* _(RefSubject.make(Effect.succeed(0)))
+          // Effect/Fx-backed RefSubjects require being initialized
+          yield* _(ref)
+
+          expect(RefSubject.unsafeGet(ref)).toEqual(0)
+        }).pipe(Effect.scoped)
+
+        await Effect.runPromise(test)
+      })
+    })
   })
 
   describe.concurrent("Subject", () => {


### PR DESCRIPTION
## RefSubject.get
- Works on `RefSubject`, `Computed`, and `Filtered`, returning an Effect for their current values.

## RefSubject.unsafeGetExit

The `unsafeGet` method has been added to each interface for `RefSubject`, `Computed`, and `Filtered`, and this function just defers to their implementations.

It truly is UNSAFE, and WILL throw if a value has not been initialized. For `RefSubject`, only `RefSubject.of(value)`, has a value directly after construction, all others will still require being initialized in an Effect runtime before being called, or else it will throw a `Cause.NoSuchElementException`. For more custom use cases, `RefSubject.unsafeMake` accepts an `initialValue` option as well.

There are `RefSubject.tagged` and `RefSubject.fromTag` which will immediately throw with an error message that they do not support `unsafeGet` at all because they require the Effect context by definition. If this is necessary, use `RefSubject.provide` to provide those services, and use `Effect.runSync(RefSubject.get(ref))`

For Computed and Filtered, because they both require Effectful computations, they always require an initialization before being able to sucessfully call `unsafeGetExit`

## RefSubject.unsafeGet

This is implemented as just `Effect.runSync(RefSubject.unsafeGetExit(ref))`, such that any Exit failures are thrown with their Causes in the same way that Effect would.


----------------------------------------------------------------------------------------------------------------------------

Possibly closes #46 